### PR TITLE
Suporte ao MacOS com Qt 5.5

### DIFF
--- a/Depixel/SimilarityGraphExportToImage.cpp
+++ b/Depixel/SimilarityGraphExportToImage.cpp
@@ -3,6 +3,8 @@
 #include "Depixel/SimilarityGraph.h"
 #include "Image.h"
 
+#include <cmath>
+
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 
 SimilarityGraphExportToImage::SimilarityGraphExportToImage( SimilarityGraph* similarityGraph ) :

--- a/Filters/Filter.cpp
+++ b/Filters/Filter.cpp
@@ -1,5 +1,8 @@
 #include "Filter.h"
+
+#if defined(__linux__) || defined(_WIN32)
 #include <omp.h>
+#endif
 
 Filter::Filter( Image* inputImage, Image* outputImage ) :
     _inputImage( inputImage ),

--- a/Filters/hqx/HqxCommon.h
+++ b/Filters/hqx/HqxCommon.h
@@ -24,7 +24,10 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+
+#if defined(__linux__) || defined(_WIN32)
 #include <omp.h>
+#endif
 
 #define MASK_2     0x0000FF00
 #define MASK_13    0x00FF00FF
@@ -41,6 +44,9 @@
 #ifdef _WIN32
 #define u_int32_t uint32_t
 #define u_int8_t uint8_t
+#elif defined __clang__
+typedef u_int32_t uint32_t;
+typedef uint8_t u_int8_t;
 #endif
 
 /* RGB to YUV lookup table */

--- a/Filters/xBRZ/xbrz.cpp
+++ b/Filters/xBRZ/xbrz.cpp
@@ -14,8 +14,13 @@
 // ****************************************************************************
 
 #include "xbrz.h"
+#include <cmath>
 #include <cassert>
 #include <algorithm>
+
+#ifdef __clang__
+typedef uint32_t u_int;
+#endif
 
 namespace
 {

--- a/Image.h
+++ b/Image.h
@@ -7,6 +7,9 @@
 #ifdef _WIN32
 #define u_int uint32_t
 #define u_char uint8_t
+#elif defined __clang__
+typedef uint32_t u_int;
+typedef uint8_t u_char;
 #endif
 
 class Image

--- a/dpixel.pro
+++ b/dpixel.pro
@@ -5,9 +5,9 @@
 #-------------------------------------------------
 
 QT       += core gui opengl
-LIBS     += -fopenmp
+CONFIG += C++11
 
-QMAKE_CXXFLAGS += -fopenmp -std=c++11
+unix:!macx:LIBS += -fopenmp
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 

--- a/main.cpp
+++ b/main.cpp
@@ -33,11 +33,17 @@
 
 #include "MainWindow.h"
 #include <QApplication>
+
+#if defined(__linux__) || defined(_WIN32)
 #include <omp.h>
+#endif
 
 int main( int argc, char* argv[] )
 {
+#if defined(__linux__) || defined(_WIN32)
     omp_set_num_threads( omp_get_max_threads() );
+#endif
+
     QApplication a( argc, argv );
     MainWindow w;
     w.show();


### PR DESCRIPTION
Modificações para compilar no MacOS

Basicamente não tem OMP por padrão, ai é melhor tirar. 

Tinha vários typedefs que precisam ser definidos pra compilar com o clang

Compilei usando o Qt5.5 e clang 7.3